### PR TITLE
Fixed HTTPX version requirements for Langserve

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,6 +11,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.11"
 uvicorn = "^0.23.2"
+httpx = "^0.25"
 langserve = {extras = ["server"], version = ">=0.0.30"}
 pydantic = "<2"
 neo4j-chains = {path = "packages/neo4j-chains", develop = true}


### PR DESCRIPTION
This fixes for now the build problem of the docker compose. On the long run both versions of Langserve and HTTPX should be upgraded to the most recent. 